### PR TITLE
Consider receive flag in the config to avoid an error message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -164,7 +164,9 @@ export class CanBusAdapter extends utils.Adapter {
 
         case 'json':
           // let the parsers read the data from json to keep the parsers data in sync with the json data
-          await this.processParsers(this.getBufferFromJsonState(state, msgCfg.idWithDlc), msgCfg);
+          if (msgCfg.receive) {
+            await this.processParsers(this.getBufferFromJsonState(state, msgCfg.idWithDlc), msgCfg);
+          }
 
           // send current json data
           if (msgCfg.autosend) {
@@ -590,9 +592,12 @@ export class CanBusAdapter extends utils.Adapter {
     if (!buf) return;
 
     for (const parserUuid in msgCfg.parsers) {
+
       // check if the parser is initialized
       const parser = msgCfg.parsers[parserUuid];
+
       if (parser.instance) {
+
         const readResult = await parser.instance.read(buf);
         // check if the parser has read a value (null indicates an error)
         if (readResult instanceof Error) {

--- a/src/parsers/custom.ts
+++ b/src/parsers/custom.ts
@@ -76,7 +76,7 @@ export class ParserCustom extends ParserBase {
         this.adapter.log.warn(`Error loading custom read script for parser ${this.cfg.id}! ${err}`);
       }
     } else {
-      this.adapter.log.warn(`No read script defined for parser ${this.cfg.id}! Data cannot be read.`);
+      this.adapter.log.info(`No read script defined for parser ${this.cfg.id}! Data cannot be read.`);
     }
 
     // prepare write script


### PR DESCRIPTION
Consider receive flag in the config to avoid an error message if no read script is stored for a custom parser.